### PR TITLE
Add simple quiz app and docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+*.py[cod]
+.DS_Store

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2023
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,1 +1,11 @@
 # Codex2
+
+Codex2 is a simple command-line quiz application.
+
+## Usage
+Run `python quiz.py` to start the quiz.
+
+## Future Plans
+- Add more questions
+- Support for saving high scores
+

--- a/quiz.py
+++ b/quiz.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python3
+
+"""Simple command-line quiz app."""
+
+QUESTIONS = [
+    ("What is the capital of France?", "Paris"),
+    ("What is 2 + 2?", "4"),
+    ("Who wrote '1984'?", "George Orwell"),
+]
+
+
+def main() -> None:
+    score = 0
+    for question, answer in QUESTIONS:
+        user_answer = input(question + " ")
+        if user_answer.strip().lower() == answer.lower():
+            print("Correct!")
+            score += 1
+        else:
+            print(f"Incorrect. The correct answer is {answer}.")
+    print(f"You got {score}/{len(QUESTIONS)} correct.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- expand README with usage instructions and future plans
- add MIT license
- add .gitignore for Python artifacts
- implement a command-line quiz application in `quiz.py`

## Testing
- `python3 -m py_compile quiz.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68462d3edd8483229a279b88a4635869