### PR TITLE
Add advanced quiz features

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+*.py[cod]
+.DS_Store

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2023
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,1 +1,19 @@
 # Codex2
+
+Codex2 is a feature-rich command-line quiz application written in Python.
+
+## Usage
+Run `python quiz.py` to start the quiz with default questions.
+
+Options:
+- `-f, --file PATH` &mdash; specify a custom JSON file with questions
+- `-n, --num N` &mdash; ask only the first `N` randomly selected questions
+- `--show-scores` &mdash; display previously saved high scores and exit
+
+After finishing a quiz, you can enter your name to save the result in
+`highscores.json`.
+
+## Future Plans
+- Add categories and timed quizzes
+- Improve question management through a GUI
+

--- a/questions.json
+++ b/questions.json
@@ -1,0 +1,8 @@
+[
+  {"question": "What is the capital of France?", "answer": "Paris"},
+  {"question": "What is 2 + 2?", "answer": "4"},
+  {"question": "Who wrote '1984'?", "answer": "George Orwell"},
+  {"question": "What is the boiling point of water in Celsius?", "answer": "100"},
+  {"question": "What planet is known as the Red Planet?", "answer": "Mars"},
+  {"question": "What is the largest ocean on Earth?", "answer": "Pacific"}
+]

--- a/quiz.py
+++ b/quiz.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+
+"""Feature-rich command-line quiz application."""
+
+import argparse
+import json
+import random
+from dataclasses import dataclass
+from typing import List
+
+QUESTIONS_FILE = "questions.json"
+SCORES_FILE = "highscores.json"
+
+
+@dataclass
+class Question:
+    question: str
+    answer: str
+
+
+class Quiz:
+    def __init__(self, questions: List[Question]):
+        self.questions = questions
+
+    @classmethod
+    def from_file(cls, path: str) -> "Quiz":
+        with open(path, "r", encoding="utf-8") as f:
+            data = json.load(f)
+        questions = [Question(**item) for item in data]
+        return cls(questions)
+
+    def ask(self, num_questions: int | None = None) -> int:
+        q_list = self.questions[:]
+        random.shuffle(q_list)
+        if num_questions is not None:
+            q_list = q_list[:num_questions]
+        score = 0
+        for q in q_list:
+            user_answer = input(q.question + " ")
+            if user_answer.strip().lower() == q.answer.lower():
+                print("Correct!")
+                score += 1
+            else:
+                print(f"Incorrect. The correct answer is {q.answer}.")
+        return score
+
+
+def save_score(name: str, score: int, total: int, path: str = SCORES_FILE) -> None:
+    entry = {"name": name, "score": score, "total": total}
+    try:
+        with open(path, "r", encoding="utf-8") as f:
+            scores = json.load(f)
+    except FileNotFoundError:
+        scores = []
+    scores.append(entry)
+    with open(path, "w", encoding="utf-8") as f:
+        json.dump(scores, f, indent=2)
+
+
+def show_scores(path: str = SCORES_FILE) -> None:
+    try:
+        with open(path, "r", encoding="utf-8") as f:
+            scores = json.load(f)
+    except FileNotFoundError:
+        print("No high scores yet.")
+        return
+    for entry in scores:
+        print(f"{entry['name']}: {entry['score']}/{entry['total']}")
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Quiz application")
+    parser.add_argument("-f", "--file", default=QUESTIONS_FILE,
+                        help="Path to questions JSON file")
+    parser.add_argument("-n", "--num", type=int,
+                        help="Number of questions to ask")
+    parser.add_argument("--show-scores", action="store_true",
+                        help="Display high scores and exit")
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    if args.show_scores:
+        show_scores()
+        return
+    quiz = Quiz.from_file(args.file)
+    score = quiz.ask(args.num)
+    total = args.num if args.num is not None else len(quiz.questions)
+    print(f"You got {score}/{total} correct.")
+    name = input("Enter your name for the high scores: ").strip()
+    if name:
+        save_score(name, score, total)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- README を更新し、コマンドラインオプションやハイスコアの説明を追加
- 質問を JSON ファイル `questions.json` に移動
- `quiz.py` をオブジェクト指向に書き換え、質問のランダム出題やハイスコア保存機能を実装

## Testing
- `python3 -m py_compile quiz.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68462d3edd8483229a279b88a4635869